### PR TITLE
Fixed Flaky Test givenValidResponse_whenRequestingAccessToken_thenCallDon…

### DIFF
--- a/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
+++ b/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
@@ -14,10 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.Base64;
-import java.util.List;
-import java.util.Optional;
-import java.util.Scanner;
+import java.util.*;
 
 import static com.github.jenspiegsa.wiremockextension.ManagedWireMockServer.with;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -79,12 +76,15 @@ final class SpotifyAccessTokenFetcherTest {
 
         // WHEN
         target.fetchAccessToken("myAccessCode");
-
+        String out = output.toString();
+        String newOutput = sortJsonString(out);
+        newOutput += out.substring(out.length() - 1);
+        String sortedRequestBody = sortJsonString(requestBody);
         // THEN
         String expectedMessages = "making http request for access_token..." + System.lineSeparator()
                 + "response:" + System.lineSeparator()
-                + requestBody + System.lineSeparator();
-        assertThat(output).hasToString(expectedMessages);
+                + sortedRequestBody + System.lineSeparator();
+        assertThat(newOutput).hasToString(expectedMessages);
     }
 
     @Test
@@ -160,5 +160,24 @@ final class SpotifyAccessTokenFetcherTest {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("error", "wrong data");
         return jsonObject.toString();
+    }
+
+    private String sortJsonString(String input) {
+        int start = input.indexOf('{');
+        int end = input.indexOf('}');
+        String responseBody = input.substring(start + 1, end);
+
+        String[] responseFields = responseBody.split(",");
+        Arrays.sort(responseFields);
+
+        StringBuilder sb = new StringBuilder("{");
+        for (String s: responseFields) {
+            sb.append(s);
+            sb.append(",");
+        }
+        sb.delete(sb.length() - 1, sb.length());
+        sb.append("}");
+        String sortedResponseBody = sb.toString();
+        return input.substring(0, start) + sortedResponseBody;
     }
 }


### PR DESCRIPTION
## Changes proposed:
Flakiness was found in test: ```advisor.authentication.SpotifyAccessTokenFetcherTest.givenValidResponse_whenRequestingAccessToken_thenSuccessfulMessagesAndAccessTokenArePrinted```  with an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations. The error was thrown at this line: ```assertThat(output).hasToString(expectedMessages);```. The cause of the flakiness was due to the randomly-ordered fields of the returned JSON response body referred by variable ```output```. 
The test results are below: 
```
 Expecting actual's toString() to return:
      <"making http request for access_token...
    response:
    {"expires_in":3600,"refresh_token":"AQCSmdQsvsvpneadsdq1brfKlbEWleTE3nprDwPbZgNSge5dVe_svYBG-RG-_PxIGxVvA7gSnehFJjDRAczLDbbdWPjW1yUq2gtKbbNrCQVAH5ZBtY8wAYskmOIW7zn3IEiBzg","token_type":"Bearer","access_token":"BQBSZ0CA3KR0cf0LxmiNK_E87ZqnkJKDD89VOWAZ9f0QXJcsCiHtl5Om-EVhkIfwt1AZs5WeXgfEF69e4JxL3YX6IIW9zl9WegTmgLkb4xLXWwhryty488CLoL2SM9VIY6HaHgxYxdmRFGWSzrgH3dEqcvPoLpd26D8Y","scope":""}
    ">
    but was:
      <"making http request for access_token...
    response:
    {"refresh_token":"AQCSmdQsvsvpneadsdq1brfKlbEWleTE3nprDwPbZgNSge5dVe_svYBG-RG-_PxIGxVvA7gSnehFJjDRAczLDbbdWPjW1yUq2gtKbbNrCQVAH5ZBtY8wAYskmOIW7zn3IEiBzg","token_type":"Bearer","expires_in":3600,"access_token":"BQBSZ0CA3KR0cf0LxmiNK_E87ZqnkJKDD89VOWAZ9f0QXJcsCiHtl5Om-EVhkIfwt1AZs5WeXgfEF69e4JxL3YX6IIW9zl9WegTmgLkb4xLXWwhryty488CLoL2SM9VIY6HaHgxYxdmRFGWSzrgH3dEqcvPoLpd26D8Y","scope":""}
    ">

```

## Fix of the problem
I understand that the purpose of such test is not only testing the correctness of the returned response, but also the format of the entire message. Therefore, I sliced the response body and the ```requestBody``` strings and sorted the fields in alphabetical order. Then, I inserted the sorted JSON string back to the original messages and kept the assertion statements. If the format of the entire message is not that important, a simpler fix would be just comparing the fields inside the response body. 

## Result of the fix
The test successed with Nondex runs for 3, 10, and 100 times. It can be safely concluded that the flakiness of this test is fixed

## Test Environment:
```
openjdk version "11.0.20.1"
Gradle 7.2
Ubuntu 20.04.6 LTS
Linux version: 5.4.0-163-generic
```