### PR TITLE
Fixed Flaky Test advisor.authentication.SpotifyAccessTokenFetcherTest.givenValidResponse_whenRequestingAccessToken_thenCallDoneWithCorrectHeaderAndBody

### DIFF
--- a/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
+++ b/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
@@ -14,10 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.Base64;
-import java.util.List;
-import java.util.Optional;
-import java.util.Scanner;
+import java.util.*;
 
 import static com.github.jenspiegsa.wiremockextension.ManagedWireMockServer.with;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -79,12 +76,15 @@ final class SpotifyAccessTokenFetcherTest {
 
         // WHEN
         target.fetchAccessToken("myAccessCode");
-
+        String out = output.toString();
+        String newOutput = sortJsonString(out);
+        newOutput += out.substring(out.length() - 1);
+        String sortedRequestBody = sortJsonString(requestBody);
         // THEN
         String expectedMessages = "making http request for access_token..." + System.lineSeparator()
                 + "response:" + System.lineSeparator()
-                + requestBody + System.lineSeparator();
-        assertThat(output).hasToString(expectedMessages);
+                + sortedRequestBody + System.lineSeparator();
+        assertThat(newOutput).hasToString(expectedMessages);
     }
 
     @Test
@@ -160,5 +160,24 @@ final class SpotifyAccessTokenFetcherTest {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("error", "wrong data");
         return jsonObject.toString();
+    }
+
+    private String sortJsonString(String input) {
+        int start = input.indexOf('{');
+        int end = input.indexOf('}');
+        String responseBody = input.substring(start + 1, end);
+
+        String[] responseFields = responseBody.split(",");
+        Arrays.sort(responseFields);
+
+        StringBuilder sb = new StringBuilder("{");
+        for (String s: responseFields) {
+            sb.append(s);
+            sb.append(",");
+        }
+        sb.delete(sb.length() - 1, sb.length());
+        sb.append("}");
+        String sortedResponseBody = sb.toString();
+        return input.substring(0, start) + sortedResponseBody;
     }
 }

--- a/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
+++ b/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
@@ -14,10 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.Base64;
-import java.util.List;
-import java.util.Optional;
-import java.util.Scanner;
+import java.util.*;
 
 import static com.github.jenspiegsa.wiremockextension.ManagedWireMockServer.with;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -79,13 +76,17 @@ final class SpotifyAccessTokenFetcherTest {
 
         // WHEN
         target.fetchAccessToken("myAccessCode");
-
+        String out = output.toString();
+        String newOutput = sortJsonString(out);
+        newOutput += out.substring(out.length() - 1);
+        String sortedRequestBody = sortJsonString(requestBody);
         // THEN
         String expectedMessages = "making http request for access_token..." + System.lineSeparator()
                 + "response:" + System.lineSeparator()
-                + requestBody + System.lineSeparator();
-        assertThat(output).hasToString(expectedMessages);
+                + sortedRequestBody + System.lineSeparator();
+        assertThat(newOutput).hasToString(expectedMessages);
     }
+
 
     @Test
     void givenInvalidResponse_whenRequestingAccessToken_thenNoAcessTokenIsReturned() {
@@ -160,5 +161,24 @@ final class SpotifyAccessTokenFetcherTest {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("error", "wrong data");
         return jsonObject.toString();
+    }
+
+    private String sortJsonString(String input) {
+        int start = input.indexOf('{');
+        int end = input.indexOf('}');
+        String responseBody = input.substring(start + 1, end);
+
+        String[] responseFields = responseBody.split(",");
+        Arrays.sort(responseFields);
+
+        StringBuilder sb = new StringBuilder("{");
+        for (String s: responseFields) {
+            sb.append(s);
+            sb.append(",");
+        }
+        sb.delete(sb.length() - 1, sb.length());
+        sb.append("}");
+        String sortedResponseBody = sb.toString();
+        return input.substring(0, start) + sortedResponseBody;
     }
 }

--- a/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
+++ b/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
@@ -87,7 +87,6 @@ final class SpotifyAccessTokenFetcherTest {
         assertThat(newOutput).hasToString(expectedMessages);
     }
 
-
     @Test
     void givenInvalidResponse_whenRequestingAccessToken_thenNoAcessTokenIsReturned() {
         // GIVEN


### PR DESCRIPTION
## Changes proposed
Test```advisor.authentication.SpotifyAccessTokenFetcherTest.givenValidResponse_whenRequestingAccessToken_thenCallDoneWithCorrectHeaderAndBody``` was found flaky by an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations. The error was thrown by: ```assertThat(output).hasToString(expectedMessages);```. The flakiness was resulted from the random order of the request body pattern generated by ``` RequestPatternBuilder``` from package ``` com.github.tomakehurst.wiremock.matching```. The ```expectedRequestBody``` used in the unit test was defined using a pattern with fixed order, and it will not match the ``` RequestPatternBuilder``` generated request body during shuffling; thus, the test will fail. The error messages:
```
com.github.tomakehurst.wiremock.client.VerificationException: No requests exactly matched. Most similar request was:  expected:<
    POST
    /api/token

    Authorization: Basic bXlDbGllbnRJZDpteUNsaWVudFNlY3JldA==
    Content-Type: application/x-www-form-urlencoded; charset=UTF-8

    code=myAccessCode&grant_type=authorization_code&redirect_uri=myRedirectUri> but was:<
    POST
    /api/token

    Authorization: Basic bXlDbGllbnRJZDpteUNsaWVudFNlY3JldA==
    Content-Type: application/x-www-form-urlencoded; charset=UTF-8

    code=myAccessCode&redirect_uri=myRedirectUri&grant_type=authorization_code>
```

## Fix of the problem
Since the request body for testing was generated by outside package, no changes can be made to that package. I therefore obtained the generated body pattern in a String format and sorted the elements joined by character ```&```. Similarly, I also sorted the ```expectedRequestBody``` alphabetically and compared these two sorted strings using ```assertEquals()```.  I left the part of testing the request header untouched and tested the request body using the method mentioned before. 

## Result of the fix
The test successed with Nondex runs for 3, 10, and 100 times. It can be safely concluded that the flakiness of this test is fixed

## Test Environment:
```
openjdk version "11.0.20.1"
Gradle 7.2
Ubuntu 20.04.6 LTS
Linux version: 5.4.0-163-generic
```