### PR TITLE
Fixed 2 Flaky Tests in advisor.authentication.SpotifyAccessTokenFetcherTest

### DIFF
--- a/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
+++ b/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
@@ -14,10 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.Base64;
-import java.util.List;
-import java.util.Optional;
-import java.util.Scanner;
+import java.util.*;
 
 import static com.github.jenspiegsa.wiremockextension.ManagedWireMockServer.with;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -79,12 +76,15 @@ final class SpotifyAccessTokenFetcherTest {
 
         // WHEN
         target.fetchAccessToken("myAccessCode");
-
+        String out = output.toString();
+        String newOutput = sortJsonString(out);
+        newOutput += out.substring(out.length() - 1);
+        String sortedRequestBody = sortJsonString(requestBody);
         // THEN
         String expectedMessages = "making http request for access_token..." + System.lineSeparator()
                 + "response:" + System.lineSeparator()
-                + requestBody + System.lineSeparator();
-        assertThat(output).hasToString(expectedMessages);
+                + sortedRequestBody + System.lineSeparator();
+        assertThat(newOutput).hasToString(expectedMessages);
     }
 
     @Test
@@ -160,5 +160,24 @@ final class SpotifyAccessTokenFetcherTest {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("error", "wrong data");
         return jsonObject.toString();
+    }
+
+    private String sortJsonString(String input) {
+        int start = input.indexOf('{');
+        int end = input.indexOf('}');
+        String responseBody = input.substring(start + 1, end);
+
+        String[] responseFields = responseBody.split(",");
+        Arrays.sort(responseFields);
+
+        StringBuilder sb = new StringBuilder("{");
+        for (String s: responseFields) {
+            sb.append(s);
+            sb.append(",");
+        }
+        sb.delete(sb.length() - 1, sb.length());
+        sb.append("}");
+        String sortedResponseBody = sb.toString();
+        return input.substring(0, start) + sortedResponseBody;
     }
 }

--- a/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
+++ b/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
@@ -84,13 +84,13 @@ final class SpotifyAccessTokenFetcherTest {
         // WHEN
         target.fetchAccessToken("myAccessCode");
         // THEN
-        String expectedMessages = "making http request for access_token..." + System.lineSeparator()
-                + "response:" + System.lineSeparator()
-                + requestBody + System.lineSeparator();
-        String actualMessages = output.toString();
-        JsonElement actualJson = JsonParser.parseString(actualMessages.split("response:\n")[1].trim());
-        JsonElement expectedJson = JsonParser.parseString(expectedMessages.split("response:\n")[1].trim());
-        assertThat(actualJson).isEqualTo(expectedJson);
+        String actualMessage = output.toString();
+        String responsePlaceholder = "response:" + System.lineSeparator();
+        assertThat(actualMessage).contains("making http request for access_token..." + System.lineSeparator()
+                + responsePlaceholder);
+        JsonElement actualResponseBodyJson = JsonParser.parseString(actualMessage.split(responsePlaceholder)[1].trim());
+        JsonElement expectedResponseBodyJson = JsonParser.parseString(requestBody);
+        assertThat(actualResponseBodyJson).isEqualTo(expectedResponseBodyJson);
     }
 
     @Test
@@ -150,9 +150,10 @@ final class SpotifyAccessTokenFetcherTest {
                 .withHeader(CONTENT_TYPE, equalTo("application/x-www-form-urlencoded; charset=UTF-8")));
         List<LoggedRequest> requests = findAll(postRequestedFor(urlEqualTo(API_TOKEN_URL_PATH)));
         String actualRequestBody = requests.get(0).getBodyAsString();
-        Assertions.assertTrue(actualRequestBody.contains("code=" + accessCode) &&
-                actualRequestBody.contains("grant_type=authorization_code") &&
-                actualRequestBody.contains("redirect_uri=" + REDIRECT_URI));
+        assertThat(actualRequestBody)
+                .contains("code=" + accessCode)
+                .contains("grant_type=authorization_code")
+                .contains("redirect_uri=" + REDIRECT_URI);
     }
 
     private SpotifyAccessTokenResponse buildValidResponseBody() {

--- a/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
+++ b/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
@@ -14,10 +14,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.Base64;
-import java.util.List;
-import java.util.Optional;
-import java.util.Scanner;
+import java.util.*;
 
 import static com.github.jenspiegsa.wiremockextension.ManagedWireMockServer.with;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;
@@ -79,13 +76,17 @@ final class SpotifyAccessTokenFetcherTest {
 
         // WHEN
         target.fetchAccessToken("myAccessCode");
-
+        String out = output.toString();
+        String newOutput = sortJsonString(out);
+        newOutput += out.substring(out.length() - 1);
+        String sortedRequestBody = sortJsonString(requestBody);
         // THEN
         String expectedMessages = "making http request for access_token..." + System.lineSeparator()
                 + "response:" + System.lineSeparator()
-                + requestBody + System.lineSeparator();
-        assertThat(output).hasToString(expectedMessages);
+                + sortedRequestBody + System.lineSeparator();
+        assertThat(newOutput).hasToString(expectedMessages);
     }
+
 
     @Test
     void givenInvalidResponse_whenRequestingAccessToken_thenNoAcessTokenIsReturned() {
@@ -160,5 +161,24 @@ final class SpotifyAccessTokenFetcherTest {
         JsonObject jsonObject = new JsonObject();
         jsonObject.addProperty("error", "wrong data");
         return jsonObject.toString();
+    }
+
+    private String sortJsonString(String input) {
+        int start = input.indexOf('{');
+        int end = input.indexOf('}');
+        String responseBody = input.substring(start + 1, end);
+
+        String[] responseFields = responseBody.split(",");
+        Arrays.sort(responseFields);
+
+        StringBuilder sb = new StringBuilder("{");
+        for (String s: responseFields) {
+            sb.append(s);
+            sb.append(",");
+        }
+        sb.delete(sb.length() - 1, sb.length());
+        sb.append("}");
+        String sortedResponseBody = sb.toString();
+        return input.substring(0, start) + sortedResponseBody;
     }
 }

--- a/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
+++ b/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
@@ -87,7 +87,6 @@ final class SpotifyAccessTokenFetcherTest {
         assertThat(newOutput).hasToString(expectedMessages);
     }
 
-
     @Test
     void givenInvalidResponse_whenRequestingAccessToken_thenNoAcessTokenIsReturned() {
         // GIVEN

--- a/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
+++ b/src/test/java/advisor/authentication/SpotifyAccessTokenFetcherTest.java
@@ -18,7 +18,10 @@ import com.google.gson.JsonParser;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
-import java.util.*;
+import java.util.Base64;
+import java.util.List;
+import java.util.Optional;
+import java.util.Scanner;
 
 import static com.github.jenspiegsa.wiremockextension.ManagedWireMockServer.with;
 import static com.github.tomakehurst.wiremock.client.WireMock.*;


### PR DESCRIPTION
# Test 1
## Changes proposed
Test```advisor.authentication.SpotifyAccessTokenFetcherTest.givenValidResponse_whenRequestingAccessToken_thenCallDoneWithCorrectHeaderAndBody``` was found flaky by an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations. The error was thrown by: ```assertThat(output).hasToString(expectedMessages);```. The flakiness was resulted from the random order of the request body pattern generated by ``` RequestPatternBuilder``` from package ``` com.github.tomakehurst.wiremock.matching```. The ```expectedRequestBody``` used in the unit test was defined using a pattern with fixed order, and it will not match the ``` RequestPatternBuilder``` generated request body during shuffling; thus, the test will fail. The error messages:
```
com.github.tomakehurst.wiremock.client.VerificationException: No requests exactly matched. Most similar request was:  expected:<
    POST
    /api/token

    Authorization: Basic bXlDbGllbnRJZDpteUNsaWVudFNlY3JldA==
    Content-Type: application/x-www-form-urlencoded; charset=UTF-8

    code=myAccessCode&grant_type=authorization_code&redirect_uri=myRedirectUri> but was:<
    POST
    /api/token

    Authorization: Basic bXlDbGllbnRJZDpteUNsaWVudFNlY3JldA==
    Content-Type: application/x-www-form-urlencoded; charset=UTF-8

    code=myAccessCode&redirect_uri=myRedirectUri&grant_type=authorization_code>
```

## Fix of the problem
Since the request body for testing was generated by outside package, no changes can be made to that package. I therefore obtained the generated body pattern in a String format and sorted the elements joined by character ```&```. Similarly, I also sorted the ```expectedRequestBody``` alphabetically and compared these two sorted strings using ```assertEquals()```.  I left the part of testing the request header untouched and tested the request body using the method mentioned before. 

## Result of the fix
The test successed with Nondex runs for 3, 10, and 100 times. It can be safely concluded that the flakiness of this test is fixed

## Test Environment:
```
openjdk version "11.0.20.1"
Gradle 7.2
Ubuntu 20.04.6 LTS
Linux version: 5.4.0-163-generic
```

# Test 2
## Changes proposed:
Flakiness was found in test: ```advisor.authentication.SpotifyAccessTokenFetcherTest.givenValidResponse_whenRequestingAccessToken_thenSuccessfulMessagesAndAccessTokenArePrinted```  with an open-source research tool [NonDex](https://github.com/TestingResearchIllinois/NonDex), which will shuffle implementation-dependent operations. The error was thrown at this line: ```assertThat(output).hasToString(expectedMessages);```. The cause of the flakiness was due to the randomly-ordered fields of the returned JSON response body referred by variable ```output```. 
The test results are below: 
```
 Expecting actual's toString() to return:
      <"making http request for access_token...
    response:
    {"expires_in":3600,"refresh_token":"AQCSmdQsvsvpneadsdq1brfKlbEWleTE3nprDwPbZgNSge5dVe_svYBG-RG-_PxIGxVvA7gSnehFJjDRAczLDbbdWPjW1yUq2gtKbbNrCQVAH5ZBtY8wAYskmOIW7zn3IEiBzg","token_type":"Bearer","access_token":"BQBSZ0CA3KR0cf0LxmiNK_E87ZqnkJKDD89VOWAZ9f0QXJcsCiHtl5Om-EVhkIfwt1AZs5WeXgfEF69e4JxL3YX6IIW9zl9WegTmgLkb4xLXWwhryty488CLoL2SM9VIY6HaHgxYxdmRFGWSzrgH3dEqcvPoLpd26D8Y","scope":""}
    ">
    but was:
      <"making http request for access_token...
    response:
    {"refresh_token":"AQCSmdQsvsvpneadsdq1brfKlbEWleTE3nprDwPbZgNSge5dVe_svYBG-RG-_PxIGxVvA7gSnehFJjDRAczLDbbdWPjW1yUq2gtKbbNrCQVAH5ZBtY8wAYskmOIW7zn3IEiBzg","token_type":"Bearer","expires_in":3600,"access_token":"BQBSZ0CA3KR0cf0LxmiNK_E87ZqnkJKDD89VOWAZ9f0QXJcsCiHtl5Om-EVhkIfwt1AZs5WeXgfEF69e4JxL3YX6IIW9zl9WegTmgLkb4xLXWwhryty488CLoL2SM9VIY6HaHgxYxdmRFGWSzrgH3dEqcvPoLpd26D8Y","scope":""}
    ">

```

## Fix of the problem
I understand that the purpose of such test is not only testing the correctness of the returned response, but also the format of the entire message. Therefore, I sliced the response body and the ```requestBody``` strings and sorted the fields in alphabetical order. Then, I inserted the sorted JSON string back to the original messages and kept the assertion statements. If the format of the entire message is not that important, a simpler fix would be just comparing the fields inside the response body. 

## Result of the fix
The test successed with Nondex runs for 3, 10, and 100 times. It can be safely concluded that the flakiness of this test is fixed

## Test Environment:
```
openjdk version "11.0.20.1"
Gradle 7.2
Ubuntu 20.04.6 LTS
Linux version: 5.4.0-163-generic
```